### PR TITLE
Rename the 'class' argument passed to add_settings_field() to 'callback'

### DIFF
--- a/includes/class-cl-settings-api.php
+++ b/includes/class-cl-settings-api.php
@@ -205,11 +205,11 @@ class CL_Settings_API {
 					'options' 		=> isset( $option['options'] ) ? $option['options'] : '',
 					'default'		=> isset( $option['default'] ) ? $option['default'] : '',
 					'sanitize'		=> isset( $option['sanitize'] ) ? $option['sanitize'] : '',
-					'class'			=> isset( $option['class'] ) ? $option['class'] : $this,
+					'instance'		=> isset( $option['class'] ) ? $option['class'] : $this,
 				);
 				$args = wp_parse_args( $args, $option );
 				
-				add_settings_field( $section . '[' . $option['name'] . ']', $option['label'], array( $args['class'], 'callback_' . $type ), $section, $section, $args );
+				add_settings_field( $section . '[' . $option['name'] . ']', $option['label'], array( $args['instance'], 'callback_' . $type ), $section, $section, $args );
 			}
 		}
 

--- a/includes/class-cl-settings-api.php
+++ b/includes/class-cl-settings-api.php
@@ -205,11 +205,11 @@ class CL_Settings_API {
 					'options' 		=> isset( $option['options'] ) ? $option['options'] : '',
 					'default'		=> isset( $option['default'] ) ? $option['default'] : '',
 					'sanitize'		=> isset( $option['sanitize'] ) ? $option['sanitize'] : '',
-					'instance'		=> isset( $option['class'] ) ? $option['class'] : $this,
+					'callback'		=> isset( $option['class'] ) ? $option['class'] : $this,
 				);
 				$args = wp_parse_args( $args, $option );
 				
-				add_settings_field( $section . '[' . $option['name'] . ']', $option['label'], array( $args['instance'], 'callback_' . $type ), $section, $section, $args );
+				add_settings_field( $section . '[' . $option['name'] . ']', $option['label'], array( $args['callback'], 'callback_' . $type ), $section, $section, $args );
 			}
 		}
 


### PR DESCRIPTION
In WordPress 4.2, a new field was added to `add_settings_field()` with a key of 'class'. The purpose of the new argument was to make it possible to specify a CSS class for the setting container.

Unfortunately, the introduction of this new argument caused a conflict with a separate 'class' argument already in use. This PR renames that to 'callback' and all is right in the world.

See [[31560]](https://core.trac.wordpress.org/changeset/31560) for where the new argument was added to core, and [[31592]](https://core.trac.wordpress.org/changeset/31592) where the new argument was documented in the changelog for `add_settings_field()`.

This fixes #5.