### PR TITLE
Optimize Prod Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run npm install
         run: |
-          npm install --only=production
+          npm install --only=production --omit=dev
 
 #      - name: WordPress Plugin Deploy
 #        if: |


### PR DESCRIPTION
Prevent the dev dependencies from be included in a production build, since they are only needed for dev.
This should cut the final Node based packages down by like half (in my own project it did half, not guaranteeing it for yours)