### PR TITLE
Resolve "Uncaught TypeError: a is undefined" when initializing wp.cod…

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -96,7 +96,12 @@ class Settings extends AbstractContainerProvider implements OptionKey
             wp_localize_script('code-editor', $objectName, $settings);
             wp_add_inline_script(
                 'code-editor',
-                'jQuery(document).ready(function($){wp.codeEditor.initialize($(\'textarea[data-codemirror="' . $type . '"]\'), ' . $objectName . ')})'
+                'jQuery(document).ready(function($) {
+                const $textarea = $(\'textarea[data-codemirror="' . $type . '"]\')
+                if ($textarea.length > 0) {
+                    wp.codeEditor.initialize($textarea, ' . $objectName . ')
+                }
+                })'
             );
         }
 


### PR DESCRIPTION
…eEditor on empty element.

(cherry picked from commit 0d870f0f312d21b2e24bfdcc76dc55d4b84c8969)