### PR TITLE
Update softprops/action-gh-release to v2 to resolve:

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           path: plugin-build/custom-login.zip
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: plugin-build/custom-login.zip


### PR DESCRIPTION
- The following actions use a deprecated Node.js version and will be forced to run on node20: softprops/action-gh-release@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/